### PR TITLE
chore: eslint rule 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
         "unnamedComponents": "function-expression"
       }
     ],
-    "func-style": ["error", "declaration", { "allowArrowFunctions": true }]
+    "func-style": ["error", "declaration", { "allowArrowFunctions": true }],
+    "@typescript-eslint/no-unused-vars": "warn"
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,27 +1,10 @@
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 html,
 body {
   max-width: 100vw;
-  overflow-x: hidden;
 }
 
 body {
-  color: var(--foreground);
-  background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 * {
@@ -33,10 +16,4 @@ body {
 a {
   color: inherit;
   text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }


### PR DESCRIPTION
1. `no-unused-vars` 에러를 warning 으로 변경
```js
// .eslintrc.json
{
  // ...
  "rules": {
  // ...
  "@typescript-eslint/no-unused-vars": "warn"
  }
}
```


2. 불필요한 global css제거
global css는 추후 구체적으로 정해보면 좋을거같습니다